### PR TITLE
Kinto updater improvements

### DIFF
--- a/services/common/kinto-updater.js
+++ b/services/common/kinto-updater.js
@@ -16,6 +16,7 @@ const PREF_KINTO_BUCKET = "services.kinto.bucket";
 const PREF_KINTO_LAST_UPDATE = "services.kinto.last_update_seconds";
 const PREF_KINTO_LAST_TIMESTAMP = "services.kinto.last_timestamp";
 const PREF_KINTO_CLOCK_SKEW_SECONDS = "services.kinto.clock_skew_seconds";
+const PREF_KINTO_ONECRL_COLLECTION = "services.kinto.onecrl.collection";
 
 const kintoClients = {
 };
@@ -97,6 +98,5 @@ this.addTestKintoClient = function(name, kintoClient) {
 };
 
 // Add the various things that we know want updates
-kintoClients.certificates =
-  Cu.import("resource://services-common/KintoCertificateBlocklist.js", {})
-  .OneCRLClient;
+const KintoBlocklist = Cu.import("resource://services-common/KintoCertificateBlocklist.js", {});
+kintoClients[Services.prefs.getCharPref(PREF_KINTO_ONECRL_COLLECTION)]  = KintoBlocklist.OneCRLClient;

--- a/services/common/kinto-updater.js
+++ b/services/common/kinto-updater.js
@@ -12,6 +12,7 @@ Cu.importGlobalProperties(['fetch']);
 
 const PREF_KINTO_CHANGES_PATH = "services.kinto.changes.path";
 const PREF_KINTO_BASE = "services.kinto.base";
+const PREF_KINTO_BUCKET = "services.kinto.bucket";
 const PREF_KINTO_LAST_UPDATE = "services.kinto.last_update_seconds";
 const PREF_KINTO_CLOCK_SKEW_SECONDS = "services.kinto.clock_skew_seconds";
 
@@ -33,6 +34,7 @@ this.checkVersions = function() {
     // Right now, we only use the collection name and the last modified info
     let kintoBase = Services.prefs.getCharPref(PREF_KINTO_BASE);
     let changesEndpoint = kintoBase + Services.prefs.getCharPref(PREF_KINTO_CHANGES_PATH);
+    let blocklistsBucket = Services.prefs.getCharPref(PREF_KINTO_BUCKET);
 
     let response = yield fetch(changesEndpoint);
 
@@ -46,6 +48,10 @@ this.checkVersions = function() {
 
     let firstError;
     for (let collectionInfo of versionInfo.data) {
+      // Skip changes that don't concern configured blocklist bucket.
+      if (collectionInfo.bucket != blocklistsBucket)
+        continue;
+
       let collection = collectionInfo.collection;
       let kintoClient = kintoClients[collection];
       if (kintoClient && kintoClient.maybeSync) {

--- a/services/common/tests/unit/test_kinto_updater.js
+++ b/services/common/tests/unit/test_kinto_updater.js
@@ -8,6 +8,7 @@ var server;
 
 const PREF_KINTO_BASE = "services.kinto.base";
 const PREF_LAST_UPDATE = "services.kinto.last_update_seconds";
+const PREF_LAST_TIMESTAMP = "services.kinto.last_timestamp";
 const PREF_CLOCK_SKEW_SECONDS = "services.kinto.clock_skew_seconds";
 
 // Check to ensure maybeSync is called with correct values when a changes
@@ -49,6 +50,7 @@ add_task(function* test_check_maybeSync(){
   // set some initial values so we can check these are updated appropriately
   Services.prefs.setIntPref("services.kinto.last_update", 0);
   Services.prefs.setIntPref("services.kinto.clock_difference", 0);
+  Services.prefs.setCharPref(PREF_LAST_TIMESTAMP, "");
 
 
   let startTime = Date.now();
@@ -59,7 +61,7 @@ add_task(function* test_check_maybeSync(){
     // add a test kinto client that will respond to lastModified information
     // for a collection called 'test-collection'
     updater.addTestKintoClient("test-collection", {
-      "maybeSync": function(lastModified, serverTime){
+      maybeSync: function(lastModified, serverTime){
         // ensire the lastModified and serverTime values are as expected
         do_check_eq(lastModified, 1000);
         do_check_eq(serverTime, 2000);
@@ -81,6 +83,15 @@ add_task(function* test_check_maybeSync(){
   // we previously set the serverTime to 2 (seconds past epoch)
   do_check_eq(clockDifference <= endTime / 1000
               && clockDifference >= Math.floor(startTime / 1000) - 2, true);
+
+  // Last timestamp was saved.
+  let lastTimestamp = Services.prefs.getCharPref(PREF_LAST_TIMESTAMP);
+  do_check_eq(lastTimestamp, '"1100"');
+  // If server has no change, a 304 is received, maybeSync() is not called.
+  updater.addTestKintoClient("test-collection", {
+    maybeSync: () => {throw new Error("Should not be called");}
+  });
+  yield updater.checkVersions();
 });
 
 function run_test() {
@@ -100,7 +111,8 @@ function getSampleResponse(req, port) {
   const responses = {
     "GET:/v1/buckets/monitor/collections/changes/records?": {
       "sampleHeaders": [
-        "Content-Type: application/json; charset=UTF-8"
+        "Content-Type: application/json; charset=UTF-8",
+        "ETag: \"1100\""
       ],
       "status": {status: 200, statusText: "OK"},
       "responseBody": JSON.stringify({"data":[{
@@ -118,6 +130,13 @@ function getSampleResponse(req, port) {
       }]})
     }
   };
+
+  // if (req.headers.get("If-None-Match") == '"1100"')
+  // "TypeError: req.headers.get is not a function"
+  // https://developer.mozilla.org/en-US/docs/Web/API/Request/headers
+  if (req._headers._headers["if-none-match"] && req._headers._headers["if-none-match"][0] == '"1100"')
+    return {"status": {status: 304, statusText: "Not Modified", responseBody: ""}};
+
   return responses[`${req.method}:${req.path}?${req.queryString}`] ||
          responses[req.method];
 }

--- a/services/common/tests/unit/test_kinto_updater.js
+++ b/services/common/tests/unit/test_kinto_updater.js
@@ -53,8 +53,9 @@ add_task(function* test_check_maybeSync(){
 
   let startTime = Date.now();
 
+  let updater = Cu.import("resource://services-common/kinto-updater.js");
+
   let syncPromise = new Promise(function(resolve, reject) {
-    let updater = Cu.import("resource://services-common/kinto-updater.js");
     // add a test kinto client that will respond to lastModified information
     // for a collection called 'test-collection'
     updater.addTestKintoClient("test-collection", {
@@ -102,7 +103,19 @@ function getSampleResponse(req, port) {
         "Content-Type: application/json; charset=UTF-8"
       ],
       "status": {status: 200, statusText: "OK"},
-      "responseBody": JSON.stringify({"data":[{"host":"localhost","last_modified":1000,"bucket":"blocklists","id":"330a0c5f-fadf-ff0b-40c8-4eb0d924ff6a","collection":"test-collection"}]})
+      "responseBody": JSON.stringify({"data":[{
+        "host":"localhost",
+        "last_modified":1100,
+        "bucket":"blocklists:aurora",
+        "id":"330a0c5f-fadf-ff0b-40c8-4eb0d924ff6a",
+        "collection":"test-collection"
+      }, {
+        "host":"localhost",
+        "last_modified":1000,
+        "bucket":"blocklists",
+        "id":"254cbb9e-6888-4d9f-8e60-58b74faa8778",
+        "collection":"test-collection"
+      }]})
     }
   };
   return responses[`${req.method}:${req.path}?${req.queryString}`] ||


### PR DESCRIPTION
This brings several improvements:
- Add a safety check to take advantage of buckets isolation on the server when polling for changes. In other words, ignore changes that do not match the bucket specified in configuration.
- Save bandwidth when no changes occured on the server using ETag header and `304 Not modified` responses.
- Fix inconstency where collection name was hard-coded in one place (`kinto-updater.js`) and in preference in other (`KintoCertificateBlock.js`)
